### PR TITLE
client: add functionality to replay CSV data

### DIFF
--- a/prellblock-client/Cargo.toml
+++ b/prellblock-client/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 balise = { path= "../balise", features = ["client", "tls"] }
+csv = "1.1"
 hex = "0.4.2"
 humantime = "2.0.0"
 log = "0.4.8"

--- a/prellblock-client/src/cli/options.rs
+++ b/prellblock-client/src/cli/options.rs
@@ -18,6 +18,22 @@ pub enum Cmd {
     /// Run a benchmark.
     #[structopt(name = "bench")]
     Benchmark(cmd::Benchmark),
+    /// Replay data from a CSV file.
+    ///
+    /// The first row is expected to contain a header, i.e., column
+    /// names. Subsequent rows are expected to contain data.
+    /// The first column of the data rows is expected to be a timestamp
+    /// (in seconds, float).
+    /// Data rows will be processed according to their timestamp,
+    /// relative the the first timestamp.
+    /// Values from the following columns will be set as keys (column
+    /// header) and values ("cell" contents).
+    /// As a result, data emission is being "replayed" according to the
+    /// timestamps.
+    ///
+    /// Hint: to feed from stdin, use /dev/fd/0 as input file name.
+    #[structopt(name = "csv_replay")]
+    CsvReplay(cmd::CsvReplay),
     /// Update an account.
     #[structopt(name = "update_account")]
     UpdateAccount(cmd::UpdateAccount),
@@ -74,6 +90,12 @@ pub mod cmd {
         /// Print the TPS number to stdout.
         #[structopt(short, long)]
         pub print_tps: bool,
+    }
+
+    /// Replay setting key/values from CSV file
+    #[derive(StructOpt, Debug)]
+    pub struct CsvReplay {
+        pub csv_file: String,
     }
 
     /// Update the permissions for a given account.


### PR DESCRIPTION
example invocation:
```
$ ./prellblock-client my-rpu.key 127.0.0.1:3130 csv_replay my.csv
```

The CSV may look like this:

```
timestamp,n/a 1,n/a 2,n/a 3,n/a 4, …
1559883150.52,36,36,4,201,…
1559883151.04,36,36,5,199,…
1559883151.55,36,36,5,196,…
```

Timestamps need to be floats and sorted.